### PR TITLE
fix: use latest `react-scripts-ts` for security

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "chunkcan",
+	"name": "timeliners",
 	"version": "0.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
@@ -1341,9 +1341,9 @@
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "2.5.5",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
-					"integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=",
+					"version": "2.5.6",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.6.tgz",
+					"integrity": "sha512-lQUVfQi0aLix2xpyjrrJEvfuYCqPc/HwmTKsC/VNf8q0zsjX7SQZtp4+oRONN5Tsur9GDETPjj+Ub2iDiGZfSQ==",
 					"dev": true
 				},
 				"source-map": {
@@ -1374,9 +1374,9 @@
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "2.5.5",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
-					"integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=",
+					"version": "2.5.6",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.6.tgz",
+					"integrity": "sha512-lQUVfQi0aLix2xpyjrrJEvfuYCqPc/HwmTKsC/VNf8q0zsjX7SQZtp4+oRONN5Tsur9GDETPjj+Ub2iDiGZfSQ==",
 					"dev": true
 				}
 			}
@@ -1976,16 +1976,25 @@
 			}
 		},
 		"caniuse-db": {
-			"version": "1.0.30000833",
-			"resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000833.tgz",
-			"integrity": "sha1-K9e+cqQBZY0svLj012AN7r6xxnY=",
+			"version": "1.0.30000839",
+			"resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000839.tgz",
+			"integrity": "sha1-VahuQCx0rhcUlwe+o+o5lSIjNJc=",
 			"dev": true
 		},
 		"caniuse-lite": {
-			"version": "1.0.30000833",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000833.tgz",
-			"integrity": "sha512-tKNuKu4WLImh4NxoTgntxFpDrRiA0Q6Q1NycNhuMST0Kx+Pt8YnRDW6V8xsyH6AtO2CpAoibatEk5eaEhP3O1g==",
+			"version": "1.0.30000839",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000839.tgz",
+			"integrity": "sha512-gJZIfmkuy84agOeAZc7WJOexZhisZaBSFk96gkGM6TkH7+1mBfr/MSPnXC8lO0g7guh/ucbswYjruvDbzc6i0g==",
 			"dev": true
+		},
+		"capture-exit": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-1.2.0.tgz",
+			"integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
+			"dev": true,
+			"requires": {
+				"rsvp": "^3.3.3"
+			}
 		},
 		"capture-stack-trace": {
 			"version": "1.0.0",
@@ -2591,9 +2600,9 @@
 			}
 		},
 		"create-ecdh": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.1.tgz",
-			"integrity": "sha512-iZvCCg8XqHQZ1ioNBTzXS/cQSkqkqcPs8xSX4upNB+DAk9Ht3uzQf2J32uAHNCne8LDmKr29AgZrEs4oIrwLuQ==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
+			"integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
 			"dev": true,
 			"requires": {
 				"bn.js": "^4.1.0",
@@ -3462,9 +3471,9 @@
 			"dev": true
 		},
 		"duplexify": {
-			"version": "3.5.4",
-			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.4.tgz",
-			"integrity": "sha512-JzYSLYMhoVVBe8+mbHQ4KgpvHpm0DZpJuL8PY93Vyv1fW7jYJ90LoXa1di/CVbJM+TgMs91rbDapE/RNIfnJsA==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
+			"integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
 			"dev": true,
 			"requires": {
 				"end-of-stream": "^1.0.0",
@@ -4180,14 +4189,13 @@
 			"dev": true
 		},
 		"fill-range": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-			"dev": true,
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+			"integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
 			"requires": {
 				"is-number": "^2.1.0",
 				"isobject": "^2.0.0",
-				"randomatic": "^1.1.3",
+				"randomatic": "^3.0.0",
 				"repeat-element": "^1.1.2",
 				"repeat-string": "^1.5.2"
 			}
@@ -5842,8 +5850,7 @@
 		"is-buffer": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-			"dev": true
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
 		},
 		"is-builtin-module": {
 			"version": "1.0.0",
@@ -5989,7 +5996,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
 			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-			"dev": true,
 			"requires": {
 				"kind-of": "^3.0.2"
 			}
@@ -6174,8 +6180,7 @@
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-			"dev": true
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -6187,7 +6192,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
 			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-			"dev": true,
 			"requires": {
 				"isarray": "1.0.0"
 			}
@@ -7004,7 +7008,6 @@
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-			"dev": true,
 			"requires": {
 				"is-buffer": "^1.1.5"
 			}
@@ -7315,9 +7318,9 @@
 			"dev": true
 		},
 		"make-dir": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
-			"integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+			"integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
 			"dev": true,
 			"requires": {
 				"pify": "^3.0.0"
@@ -7364,6 +7367,11 @@
 			"resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
 			"integrity": "sha1-3oGf282E3M2PrlnGrreWFbnSZqw=",
 			"dev": true
+		},
+		"math-random": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
+			"integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
 		},
 		"md5.js": {
 			"version": "1.3.4",
@@ -7824,9 +7832,9 @@
 			}
 		},
 		"node-forge": {
-			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.1.tgz",
-			"integrity": "sha1-naYR6giYL0uUIGs760zJZl8gwwA=",
+			"version": "0.7.5",
+			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.5.tgz",
+			"integrity": "sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ==",
 			"dev": true
 		},
 		"node-int64": {
@@ -10692,12 +10700,12 @@
 			}
 		},
 		"pumpify": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.4.0.tgz",
-			"integrity": "sha512-2kmNR9ry+Pf45opRVirpNuIFotsxUGLaYqxIwuR77AYrYRMuFCz9eryHBS52L360O+NcR383CL4QYlMKPq4zYA==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.0.tgz",
+			"integrity": "sha512-UWi0klDoq8xtVzlMRgENV9F7iCTZExaJQSQL187UXsxpk9NnrKGqTqqUNYAKGOzucSOxs2+jUnRNI+rLviPhJg==",
 			"dev": true,
 			"requires": {
-				"duplexify": "^3.5.3",
+				"duplexify": "^3.6.0",
 				"inherits": "^2.0.3",
 				"pump": "^2.0.0"
 			}
@@ -10774,43 +10782,24 @@
 			}
 		},
 		"randomatic": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
-			"dev": true,
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
+			"integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
 			"requires": {
-				"is-number": "^3.0.0",
-				"kind-of": "^4.0.0"
+				"is-number": "^4.0.0",
+				"kind-of": "^6.0.0",
+				"math-random": "^1.0.1"
 			},
 			"dependencies": {
 				"is-number": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"dev": true,
-					"requires": {
-						"kind-of": "^3.0.2"
-					},
-					"dependencies": {
-						"kind-of": {
-							"version": "3.2.2",
-							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
-							"requires": {
-								"is-buffer": "^1.1.5"
-							}
-						}
-					}
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
 				},
 				"kind-of": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-					"dev": true,
-					"requires": {
-						"is-buffer": "^1.1.5"
-					}
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
 				}
 			}
 		},
@@ -11003,9 +10992,9 @@
 			}
 		},
 		"react-scripts-ts": {
-			"version": "2.15.1",
-			"resolved": "https://registry.npmjs.org/react-scripts-ts/-/react-scripts-ts-2.15.1.tgz",
-			"integrity": "sha512-Gy0BSiCJtWMku5EgVaM1BW3uYBD4Lok4iIUXg3SZA4vg8tniLpX5aTvVVpOeqFS3kXCX5znBBskvrohCF2qt0g==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/react-scripts-ts/-/react-scripts-ts-3.0.0.tgz",
+			"integrity": "sha512-reZhjFvQOHUH+pM2BYEy+8o+mWvD371Rz0w2IElXjZJ83uMHAq0YDdrpaaFBQf+oKoAmuI32fAwdEtrweC/P+g==",
 			"dev": true,
 			"requires": {
 				"autoprefixer": "7.1.6",
@@ -11459,14 +11448,12 @@
 		"repeat-element": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
-			"dev": true
+			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
 		},
 		"repeat-string": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-			"dev": true
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
 		},
 		"repeating": {
 			"version": "2.0.1",
@@ -11645,6 +11632,12 @@
 				"nearley": "^2.7.10"
 			}
 		},
+		"rsvp": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+			"integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
+			"dev": true
+		},
 		"run-async": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
@@ -11699,15 +11692,16 @@
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 		},
 		"sane": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/sane/-/sane-2.5.0.tgz",
-			"integrity": "sha512-glfKd7YH4UCrh/7dD+UESsr8ylKWRE7UQPoXuz28FgmcF0ViJQhCTCCZHICRKxf8G8O1KdLEn20dcICK54c7ew==",
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/sane/-/sane-2.5.2.tgz",
+			"integrity": "sha1-tNwYYcIbQn6SlQej51HiosuKs/o=",
 			"dev": true,
 			"requires": {
 				"anymatch": "^2.0.0",
+				"capture-exit": "^1.2.0",
 				"exec-sh": "^0.2.0",
 				"fb-watchman": "^2.0.0",
-				"fsevents": "^1.1.1",
+				"fsevents": "^1.2.3",
 				"micromatch": "^3.1.4",
 				"minimist": "^1.1.1",
 				"walker": "~1.0.5",
@@ -12037,12 +12031,12 @@
 			"dev": true
 		},
 		"selfsigned": {
-			"version": "1.10.2",
-			"resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.2.tgz",
-			"integrity": "sha1-tESVgNmZKbZbEKSDiTAaZZIIh1g=",
+			"version": "1.10.3",
+			"resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.3.tgz",
+			"integrity": "sha512-vmZenZ+8Al3NLHkWnhBQ0x6BkML1eCP2xEi3JE+f3D9wW9fipD9NNJHYtE9XJM4TsPaHGZJIamrSI6MTg1dU2Q==",
 			"dev": true,
 			"requires": {
-				"node-forge": "0.7.1"
+				"node-forge": "0.7.5"
 			}
 		},
 		"semver": {
@@ -12709,14 +12703,14 @@
 			}
 		},
 		"stream-http": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.1.tgz",
-			"integrity": "sha512-cQ0jo17BLca2r0GfRdZKYAGLU6JRoIWxqSOakUMuKOT6MOK7AAlE856L33QuDmAy/eeOrhLee3dZKX0Uadu93A==",
+			"version": "2.8.2",
+			"resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.2.tgz",
+			"integrity": "sha512-QllfrBhqF1DPcz46WxKTs6Mz1Bpc+8Qm6vbqOpVav5odAXwbyzwnEczoWqtxrsmlO+cJqtPrp/8gWKWjaKLLlA==",
 			"dev": true,
 			"requires": {
 				"builtin-status-codes": "^3.0.0",
 				"inherits": "^2.0.1",
-				"readable-stream": "^2.3.3",
+				"readable-stream": "^2.3.6",
 				"to-arraybuffer": "^1.0.0",
 				"xtend": "^4.0.0"
 			}
@@ -13630,9 +13624,9 @@
 			}
 		},
 		"tsconfig-paths": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.3.1.tgz",
-			"integrity": "sha512-NDoPsyNh5auc3NrTPP9x7htaROU4JXaSoc53O7fvvJJrU639Jcz7NJgntoyiLDVIPItPXYWUYPf94Wfqqf14pg==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.3.2.tgz",
+			"integrity": "sha512-21VLRJIXGZDaZ0YVml12IXwSyEcluxvBZjS9xY5ZiKle0iF9NmNg7Hatb77FDg5Ahkas3dfvST8IDldMYpCH0g==",
 			"dev": true,
 			"requires": {
 				"deepmerge": "^2.0.1",
@@ -13692,9 +13686,9 @@
 			"dev": true
 		},
 		"tslint-react": {
-			"version": "3.5.1",
-			"resolved": "https://registry.npmjs.org/tslint-react/-/tslint-react-3.5.1.tgz",
-			"integrity": "sha512-ndS/iOOGrasATcf5YU3JxoIwPGVykjrKhzmlVsRdT1xzl/RbNg9n627rtAGbCjkQepyiaQYgxWQT5G/qUpQCaA==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/tslint-react/-/tslint-react-3.6.0.tgz",
+			"integrity": "sha512-AIv1QcsSnj7e9pFir6cJ6vIncTqxfqeFF3Lzh8SuuBljueYzEAtByuB6zMaD27BL0xhMEqsZ9s5eHuCONydjBw==",
 			"dev": true,
 			"requires": {
 				"tsutils": "^2.13.1"
@@ -13774,9 +13768,9 @@
 			"integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
 		},
 		"uglify-js": {
-			"version": "3.3.23",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.23.tgz",
-			"integrity": "sha512-Ks+KqLGDsYn4z+pU7JsKCzC0T3mPYl+rU+VcPZiQOazjE4Uqi4UCRY3qPMDbJi7ze37n1lDXj3biz1ik93vqvw==",
+			"version": "3.3.24",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.24.tgz",
+			"integrity": "sha512-hS7+TDiqIqvWScCcKRybCQzmMnEzJ4ryl9ErRmW4GFyG48p0/dKZiy/5mVLbsFzU8CCnCgQdxMiJzZythvLzCg==",
 			"dev": true,
 			"requires": {
 				"commander": "~2.15.0",
@@ -13807,21 +13801,27 @@
 			},
 			"dependencies": {
 				"ajv": {
-					"version": "6.4.0",
-					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.4.0.tgz",
-					"integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
+					"version": "6.5.0",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.0.tgz",
+					"integrity": "sha512-VDUX1oSajablmiyFyED9L1DFndg0P9h7p1F+NO8FkIzei6EPrR6Zu1n18rd5P8PqaSRd/FrWv3G1TVBqpM83gA==",
 					"dev": true,
 					"requires": {
-						"fast-deep-equal": "^1.0.0",
+						"fast-deep-equal": "^2.0.1",
 						"fast-json-stable-stringify": "^2.0.0",
 						"json-schema-traverse": "^0.3.0",
-						"uri-js": "^3.0.2"
+						"uri-js": "^4.2.1"
 					}
 				},
 				"commander": {
 					"version": "2.13.0",
 					"resolved": "https://registry.npmjs.org/commander/-/commander-2.13.0.tgz",
 					"integrity": "sha512-MVuS359B+YzaWqjCL/c+22gfryv+mCBPHAv3zyVI2GN8EY6IRP8VwtasXn8jyyhvvq84R4ImN1OKRtcbIasjYA==",
+					"dev": true
+				},
+				"fast-deep-equal": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+					"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
 					"dev": true
 				},
 				"schema-utils": {
@@ -14030,9 +14030,9 @@
 			"dev": true
 		},
 		"uri-js": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-3.0.2.tgz",
-			"integrity": "sha1-+QuFhQf4HepNz7s8TD2/orVX+qo=",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.1.tgz",
+			"integrity": "sha512-jpKCA3HjsBfSDOEgxRDAxQCNyHfCPSbq57PqCkd3gAyBuPb3IWxw54EHncqESznIdqSetHfw3D7ylThu2Kcc9A==",
 			"dev": true,
 			"requires": {
 				"punycode": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"now": "^11.1.7",
 		"npm-run-all": "^4.1.2",
 		"nsp": "^3.2.1",
-		"react-scripts-ts": "2.15.1",
+		"react-scripts-ts": "^3.0.0",
 		"tslint": "^5.9.1",
 		"typescript": "^2.8.3"
 	}


### PR DESCRIPTION
Als je de laatste npm installeerd (`npm install -g npm@latest`) dan heb je een tool genaamd `npm audit`. Deze geeft mogelijke security issues in dependencies weer. Door deze fix zijn er ±80 issues verholpen.